### PR TITLE
Merge dputler's GLM and cafreeman LM forks

### DIFF
--- a/src/main/scala/com/Alteryx/sparkGLM/GLM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/GLM.scala
@@ -1,0 +1,69 @@
+package com.Alteryx.sparkGLM
+
+import breeze.linalg._
+import breeze.numerics._
+import breeze.stats.distributions._
+
+import org.apache.commons.math3.distribution._
+
+import edu.berkeley.cs.amplab.mlmatrix
+import edu.berkeley.cs.amplab.mlmatrix._
+import edu.berkeley.cs.amplab.mlmatrix.{NormalEquations, RowPartitionedMatrix}
+import edu.berkeley.cs.amplab.mlmatrix.util.Utils
+import edu.berkeley.cs.amplab.mlmatrix.NormalEquations._
+
+import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import org.apache.spark.storage.StorageLevel
+import org.apache.spark.util.Utils
+import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{DataFrame, Row}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions
+
+case class GLM(xnames: Array[String],
+              yname: String,
+              coefs: DenseMatrix[Double],
+              stdErr: Array[Double],
+              dfResidual: Double,
+              dfNull: Double,
+              deviance: Double,
+              nullDeviance: Double,
+              pDispersion: Double,
+              pearson: Double,
+              loglik: Double,
+              family: String,
+              link: String,
+              aic: Double,
+              iter: Int)
+
+object GLM {
+
+  // Family and link methods
+  /// Family specific methods
+  //// Binomial
+  def varianceBinomial(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    mu :* (1.0 :+ (-1.0 :* (mu :/ m)))
+  }
+
+// NEARLY THERE, THE ISSUE IS APPLYING A FUNCTION TO ELEMENTS OF
+// DIFFERENT COLUMNS TO GET THE CDF VALUE. HERE IS A RELEVANT
+// CODE SNIPPET:
+// val a = Binomial(1, 0.5).logProbabilityOf(1)
+// this is of the form Binomial(m, mu).logProbabilityOf(y)
+  def llBinomial(
+      y: DenseMatrix[Double],
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val vals = m.toArray.zip(mu.toArray).zip(y.toArray).map {
+      case((a, b), c) => Array(a, b, c)
+    }
+    val ll = vals.map {
+      x => Array(Binomial(x(0).toInt, x(1)).logProbabilityOf(x(2).toInt))
+    }.map(y => y(0))
+    new DenseMatrix(rows = y.rows, cols = 1, ll)
+  }
+}

--- a/src/main/scala/com/Alteryx/sparkGLM/GLM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/GLM.scala
@@ -43,17 +43,14 @@ object GLM {
   // Family and link methods
   /// Family specific methods
   //// Binomial
+  ///// Binomial variance
   def varianceBinomial(
       mu: DenseMatrix[Double],
       m: DenseMatrix[Double]): DenseMatrix[Double] = {
     mu :* (1.0 :+ (-1.0 :* (mu :/ m)))
   }
 
-// NEARLY THERE, THE ISSUE IS APPLYING A FUNCTION TO ELEMENTS OF
-// DIFFERENT COLUMNS TO GET THE CDF VALUE. HERE IS A RELEVANT
-// CODE SNIPPET:
-// val a = Binomial(1, 0.5).logProbabilityOf(1)
-// this is of the form Binomial(m, mu).logProbabilityOf(y)
+  ///// Binomial likelihood
   def llBinomial(
       y: DenseMatrix[Double],
       mu: DenseMatrix[Double],
@@ -65,5 +62,99 @@ object GLM {
       x => Array(Binomial(x(0).toInt, x(1)).logProbabilityOf(x(2).toInt))
     }.map(y => y(0))
     new DenseMatrix(rows = y.rows, cols = 1, ll)
+  }
+
+  //// Binomial deviance
+  def devBinomial(
+      y: DenseMatrix[Double],
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): Double = {
+    val my = m :+ (-1.0 :* mu)
+    val rowValue = y :* breeze.numerics.log(max(y, 1.0) :/ mu) + my :* breeze.numerics.log(max(my, 1.0) :/ (m :+ (-1.0 :* mu)))
+    val deviance = (utils.repValue(1.0, rowValue.rows) * rowValue).toArray
+    2*deviance(0)
+  }
+
+  ///// Binomial Deviance Residuals (included for possible future use)
+//  def devResidsBinomial(
+//      y: DenseMatrix[Double],
+//      mu: DenseMatrix[Double],
+//      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+//    val vals = y.toArray.zip(mu.toArray).zip(m.toArray).map {
+//      case((a, b), c) => Array(a, b, c)
+//    }
+//    val devs = vals.map {
+//      x => Array(utils.sign(x(0) - x(1)) * sqrt(2.0 * ))
+//    }.map(y => y(0))
+//      new DenseMatrix(rows = y.rows, cols = 1, devs)
+//    new DenseMatrix(rows = y.rows, cols = 1, devs)
+//  }
+
+  /// Link function specific methods
+  //// Binomial
+  ///// Logit
+  def linkLogit(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    breeze.numerics.log(mu :/ (m :+ (-1.0 :* mu)))
+  }
+  def lPrimeLogit(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    m :/ (mu :* (m :+ (-1.0 :* mu)))
+  }
+  def unlinkLogit(
+      eta: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    m :/ (1.0 :+ breeze.numerics.exp(-eta))
+  }
+
+  ///// Probit
+  def linkProbit(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val muM = mu.toArray.zip(m.toArray)
+    val linkRow = muM.map {
+      x => Array(Gaussian(0.0, 1.0).icdf(x._1/x._2))
+    }.map(y => y(0))
+    new DenseMatrix(rows = mu.rows, cols = 1, linkRow)
+  }
+  def lPrimeProbit(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val link = linkProbit(mu, m)
+    val mLink = m.toArray.zip(link.toArray)
+    val lPrimeRow = mLink.map {
+      x => Array(1.0 / (x._1 * Gaussian(0.0, 1.0).pdf(x._2)))
+    }.map(y => y(0))
+    new DenseMatrix(rows = mu.rows, cols = 1, lPrimeRow)
+  }
+  def unlinkProbit(
+      eta: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    val mEta = m.toArray.zip(eta.toArray)
+    val unlinkRow = mEta.map {
+      x => Array(x._1 * Gaussian(0.0, 1.0).cdf(x._2))
+    }.map(y => y(0))
+    new DenseMatrix(rows = eta.rows, cols = 1, unlinkRow)
+  }
+
+
+  ///// Complimentary log-log
+  def linkCloglog(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    breeze.numerics.log(-1.0 :* breeze.numerics.log(1.0 :+ -1.0 :* (mu :/ m)))
+  }
+  def lPrimeCloglog(
+      mu: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    1.0 :/ ((mu :+ (-1.0 :* m)) :* breeze.numerics.log(1.0 :+ (-1.0 :* (mu :/ m))))
+  }
+  def unlinkCloglog(
+      y: DenseMatrix[Double],
+      eta: DenseMatrix[Double],
+      m: DenseMatrix[Double]): DenseMatrix[Double] = {
+    m :* (1.0 :+ -1.0 :* breeze.numerics.exp(-breeze.numerics.exp(eta)))
   }
 }

--- a/src/main/scala/com/Alteryx/sparkGLM/LM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/LM.scala
@@ -2,6 +2,8 @@ package com.Alteryx.sparkGLM
 
 import breeze.linalg._
 import breeze.numerics._
+import breeze.stats.distributions._
+
 import edu.berkeley.cs.amplab.mlmatrix
 import edu.berkeley.cs.amplab.mlmatrix._
 import edu.berkeley.cs.amplab.mlmatrix.{NormalEquations, RowPartitionedMatrix}
@@ -222,6 +224,7 @@ object LM {
     val dfe = obj.nrow.toInt - obj.xnames.size
     val coefArray = obj.coefs.toArray
     val tVals = coefArray.zip(obj.stdErr).map(x => x._1/x._2)
+    val pVals = tVals.map(x => 2.0*(1.0 - StudentsT(dfe.toDouble).cdf(scala.math.abs(x))))
     var formula = obj.xnames(0)
     for (i <- 1 to (obj.xnames.size - 1)) {
       formula = formula + " + " + obj.xnames(i)
@@ -231,9 +234,9 @@ object LM {
     println(formula)
     println("\n")
     println("Coefficients:")
-    println(String.format("%-12s %12s %12s %12s", "", "Estimate", "Std. Error", "t value"))
+    println(String.format("%-12s %12s %12s %12s %12s", "", "Estimate", "Std. Error", "t value", "Pr(>|t|)"))
     for (i <- 0 to (obj.xnames.size - 1)) {
-      println(String.format("%-12s %12s %12s %12s",obj.xnames(i), utils.sigDigits(coefArray(i), 6).toString, utils.sigDigits(obj.stdErr(i), 6).toString, utils.sigDigits(tVals(i), 6).toString))
+      println(String.format("%-12s %12s %12s %12s %12s",obj.xnames(i), utils.sigDigits(coefArray(i), 6).toString, utils.sigDigits(obj.stdErr(i), 6).toString, utils.sigDigits(tVals(i), 6).toString, utils.sigDigits(pVals(i), 6).toString))
     }
     println("\n")
     println("Residual standard error: " + utils.sigDigits(obj.sigma, 6).toString + " on " + dfe.toString + " degress of freedom")

--- a/src/main/scala/com/Alteryx/sparkGLM/LM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/LM.scala
@@ -215,6 +215,7 @@ object LM {
   // for getting p-values from various distributions don't really exist. There seems
   // to be a way to get a chi-square statistic via MLlib, but we aren't sure what
   // is being called under the hood. Likely the Apache Commons Java Math classes.
+  // Actually, no: val pValue = 1 - StudentsT(200.0).cdf(1.9)
   def summary(obj: LM) = {
     val adjR2 = 1.0 - (((1.0 - obj.r2)*(obj.nrow - 1.0))/(obj.nrow - obj.xnames.size - 1.0))
     val dfm = obj.xnames.size - 1

--- a/src/main/scala/com/Alteryx/sparkGLM/LM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/LM.scala
@@ -46,12 +46,11 @@ object LM {
     val XtX_Xty = XY.map { part =>
       (part._1.t * part._1, part._1.t * part._2)
     }
+    val treeBranchingFactor = X.rdd.context.getConf.getInt("spark.mlmatrix.treeBranchingFactor", 2).toInt
+    val depth = math.ceil(math.log(XtX_Xty.partitions.size)/math.log(treeBranchingFactor)).toInt
+    val reduced = edu.berkeley.cs.amplab.mlmatrix.util.Utils.treeReduce(XtX_Xty, utils.reduceNormal, depth=depth)
 
-      val treeBranchingFactor = X.rdd.context.getConf.getInt("spark.mlmatrix.treeBranchingFactor", 2).toInt
-      val depth = math.ceil(math.log(XtX_Xty.partitions.size)/math.log(treeBranchingFactor)).toInt
-      val reduced = edu.berkeley.cs.amplab.mlmatrix.util.Utils.treeReduce(XtX_Xty, utils.reduceNormal, depth=depth)
-
-      reduced
+    reduced
   }
 
 

--- a/src/main/scala/com/Alteryx/sparkGLM/LM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/LM.scala
@@ -41,13 +41,13 @@ object LM {
       X: RowPartitionedMatrix,
       Y: RowPartitionedMatrix): (DenseMatrix[Double], DenseMatrix[Double])  = {
     val XY = X.rdd.zip(Y.rdd).map(x => (x._1.mat, x._2.mat))
-    val ATA_ATb = XY.map { part =>
+    val XtX_Xty = XY.map { part =>
       (part._1.t * part._1, part._1.t * part._2)
     }
 
       val treeBranchingFactor = X.rdd.context.getConf.getInt("spark.mlmatrix.treeBranchingFactor", 2).toInt
-      val depth = math.ceil(math.log(ATA_ATb.partitions.size)/math.log(treeBranchingFactor)).toInt
-      val reduced = edu.berkeley.cs.amplab.mlmatrix.util.Utils.treeReduce(ATA_ATb, utils.reduceNormal, depth=depth)
+      val depth = math.ceil(math.log(XtX_Xty.partitions.size)/math.log(treeBranchingFactor)).toInt
+      val reduced = edu.berkeley.cs.amplab.mlmatrix.util.Utils.treeReduce(XtX_Xty, utils.reduceNormal, depth=depth)
 
       reduced
   }

--- a/src/main/scala/com/Alteryx/sparkGLM/LM.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/LM.scala
@@ -225,6 +225,8 @@ object LM {
     val coefArray = obj.coefs.toArray
     val tVals = coefArray.zip(obj.stdErr).map(x => x._1/x._2)
     val pVals = tVals.map(x => 2.0*(1.0 - StudentsT(dfe.toDouble).cdf(scala.math.abs(x))))
+    val pFa = new FDistribution(dfm.toDouble, dfe.toDouble)
+    val pF = 1.0 - pFa.cdf(obj.fStat)
     var formula = obj.xnames(0)
     for (i <- 1 to (obj.xnames.size - 1)) {
       formula = formula + " + " + obj.xnames(i)
@@ -241,6 +243,6 @@ object LM {
     println("\n")
     println("Residual standard error: " + utils.sigDigits(obj.sigma, 6).toString + " on " + dfe.toString + " degress of freedom")
     println("Multiple R-Squared: " + utils.roundDigits(obj.r2, 4).toString + ", Adusted R-Squared: " + utils.roundDigits(adjR2, 4).toString)
-    println("F-statistic: " + utils.sigDigits(obj.fStat, 5).toString + " on " + dfm.toString + " and " + dfe.toString + " DF")
+    println("F-statistic: " + utils.sigDigits(obj.fStat, 5).toString + " on " + dfm.toString + " and " + dfe.toString + " DF, p-value: " + utils.sigDigits(pF, 4).toString)
   }
 }

--- a/src/main/scala/com/Alteryx/sparkGLM/utils.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/utils.scala
@@ -3,7 +3,9 @@ package com.Alteryx.sparkGLM
 import breeze.linalg._
 import breeze.numerics._
 
-import edu.berkeley.cs.amplab.mlmatrix.RowPartitionedMatrix
+import edu.berkeley.cs.amplab.mlmatrix.{NormalEquations, RowPartitionedMatrix}
+import edu.berkeley.cs.amplab.mlmatrix.util.Utils
+import edu.berkeley.cs.amplab.mlmatrix.NormalEquations._
 
 import org.apache.spark.sql.{DataFrame, Column}
 import org.apache.spark.sql.functions.{col, lit}
@@ -11,6 +13,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.DoubleType
 
 object utils {
+
+  //
+  // DataFrame utility functions
+  //
 
   def matchCols (estDF: DataFrame, scoreDF: DataFrame): DataFrame = {
     val missingCols: Array[Column] = estDF.columns.diff(scoreDF.columns).map { field =>
@@ -35,6 +41,11 @@ object utils {
     dataArray(0)
   }
 
+
+  //
+  // Modelling support methods
+  //
+
   // From ml-matrix, the reducer function to sum together the partitons of X'X
   // and X'y
   def reduceNormal(
@@ -44,6 +55,59 @@ object utils {
     a._2 :+= b._2
     a
   }
+
+  // A case class for a minimal weighted least squares fit object
+  case class WLSObj(coefs: DenseMatrix[Double], diagDesign: DenseVector[Double])
+
+  // A method to do a weighted least squares fit to data in a single partition
+  def wlsSingle (
+      X: DenseMatrix[Double],
+      y: DenseMatrix[Double],
+      w: DenseMatrix[Double]): WLSObj = {
+    val W = diag(w.toDenseVector)
+    val XtWXi = inv(X.t * W * X)
+    val XtWy = X.t * W * y
+    val coefs = XtWXi * XtWy
+    val diagDesign = sqrt(diag(XtWXi))
+    new WLSObj(coefs = coefs, diagDesign = diagDesign)
+  }
+
+  // A method to get the coponents needed to do WLS on RowPartionedMatrix objects
+  def wlsComponents (
+      X: RowPartitionedMatrix,
+      y: RowPartitionedMatrix,
+      w: RowPartitionedMatrix): (DenseMatrix[Double], DenseMatrix[Double]) = {
+    val Xyw = X.rdd.zip(y.rdd).zip(w.rdd).map {
+      case((a, b), c) => (a.mat, b.mat, c.mat)
+    }
+    val XtWX_XtWy = Xyw.map { part =>
+      (part._1.t * diag(part._3.toDenseVector) * part._1,
+        part._1.t * diag(part._3.toDenseVector) * part._2)
+    }
+
+    val treeBranchingFactor = X.rdd.context.getConf.getInt("spark.mlmatrix.treeBranchingFactor", 2).toInt
+    val depth = math.ceil(math.log(XtWX_XtWy.partitions.size)/math.log(treeBranchingFactor)).toInt
+    val reduced = edu.berkeley.cs.amplab.mlmatrix.util.Utils.treeReduce(XtWX_XtWy, utils.reduceNormal, depth=depth)
+
+    reduced
+  }
+
+  // A method to do a weighted least squares fit to data in multiple partitions
+  def wlsMultiple (
+      X: RowPartitionedMatrix,
+      y: RowPartitionedMatrix,
+      w: RowPartitionedMatrix): WLSObj = {
+    val components = wlsComponents(X, y, w)
+    val XtWXi = inv(components._1)
+    val coefs = XtWXi * components._2
+    val diagDesign = sqrt(diag(XtWXi))
+    new WLSObj(coefs = coefs, diagDesign = diagDesign)
+  }
+
+
+  //
+  // Printing support methods
+  //
 
   // A method to round a number to a desired number of decimal places
   def roundDigits(num: Double, digits: Int): Double = {

--- a/src/main/scala/com/Alteryx/sparkGLM/utils.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/utils.scala
@@ -162,6 +162,6 @@ object utils {
 
     def repValue(value: Double, nrow: Int): DenseMatrix[Double] = {
       require(nrow > 0, "The number of rows must be strictly greater than 0")
-      DenseVector.fill(nrow){value}.toDenseMatrix
+      DenseVector.fill(nrow){value}.toDenseMatrix.t
     }
 }

--- a/src/main/scala/com/Alteryx/sparkGLM/utils.scala
+++ b/src/main/scala/com/Alteryx/sparkGLM/utils.scala
@@ -134,4 +134,34 @@ object utils {
       }
     }
   }
+
+  //
+  // Miscellaneous functions
+  //
+    def sign(num: Double): Double = {
+      val theSign = {
+        if (num < 0.0) {
+          -1.0
+        }
+        else if (num > 0.0) {
+          1.0
+        }
+        else {
+          0.0
+        }
+      }
+      theSign
+    }
+
+    def vecSigns(vec: DenseMatrix[Double]): DenseMatrix[Double] = {
+      require(vec.cols == 1, "The provided DenseMatrix can only have a single column")
+      val vecArray = vec.toArray
+      val signs = vecArray.map(x => sign(x))
+      new DenseMatrix(rows = signs.size, cols = 1, signs)
+    }
+
+    def repValue(value: Double, nrow: Int): DenseMatrix[Double] = {
+      require(nrow > 0, "The number of rows must be strictly greater than 0")
+      DenseVector.fill(nrow){value}.toDenseMatrix
+    }
 }

--- a/src/test/scala/com/Alteryx/sparkGLM/lmPredict$Test.scala
+++ b/src/test/scala/com/Alteryx/sparkGLM/lmPredict$Test.scala
@@ -13,7 +13,7 @@ class lmPredict$Test extends FunSuite {
     val x = testDF.select("intercept", "x")
     val y = testDF.select("y")
     val lmTest = LM.fit(x, y)
-    val predicted = LM.predict(lmTest, x)
+    val predicted = lmTest.predict(x)
 
     assert(predicted.getClass.getName == "org.apache.spark.sql.DataFrame")
     assert(predicted.rdd.partitions.size == 1)
@@ -26,7 +26,7 @@ class lmPredict$Test extends FunSuite {
     val x = testDF.select("intercept", "x")
     val y = testDF.select("y")
     val lmTest = LM.fit(x, y)
-    val predicted = LM.predict(lmTest, x)
+    val predicted = lmTest.predict(x)
 
     assert(predicted.getClass.getName == "org.apache.spark.sql.DataFrame")
     assert(predicted.rdd.partitions.length == 4)


### PR DESCRIPTION
From @dputler :

All of the `GLM` functionality! `fit` methods for multiple families:
- Logit
- Probit
- Complementary log-log

`predict` and `summary` methods, as well as supporting functions.

From @cafreeman:

Refactor the LM functionality on the Scala side to use classes. The `LM.fit` method now returns an instance of the `LM` class and contains its own `predict` and `summary` methods.
